### PR TITLE
[IMP] version 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2025-07-06
+
+### Added
+- Add `get`, `set`, and `contains` methods to the `Config` class so that it works like a dictionary.
+- Global options `--help` and `-h` to display command help
+- Add `extra_args` to `Commands` with the extra arguments that are passed
+- Add `query_get`, `query_set`, and `query_del` methods to the `Config` class to allow get, set, and delete operations on the configuration using `.` to navigate through configuration attributes.
+- Added the `ask` method to `out` for interactive user prompts.
+- Added the `path` method to `template` to obtain the absolute path of a template file.
+- New global option `--no-ansi` to disable ANSI color codes in the output.
+- Add new `add_commands` method to the `Application` class to add multiple commands.
+- When use `shell` method of the `Application` class, if set a path register it is logged in the debug.
+
+### Changed
+- Improved the `LiveText` class from `out` to ensure that all created `LiveText` instances are canceled at program exit using the `atexit` library.
+- Improved the `LiveText` class from `out` to expose the elapsed time since the object was created in an `elapsed_time` variable.
+- Modified the `init` command so that it is executed immediately after its constructor, as it did not make sense to call it before the execution of the `fire` method since there was no code in between.
+- Modified the `table` method of the `out` class to accept an optional `style` argument that allows defining the table style. If not specified, the default style is used.
+
+### Fixed
+- When using the `shell` method of the `Application` class with a specific path, after execution it ensures to return to the previous path.
+- The installation of the global bash script command `fire` previously required running `cd` to launch it. Now, it no longer performs `cd`, so when the `fire` command is executed, it reads the user's current directory. The command is installed with `fire install`.
+- Fixed the `help` command so that options with underscores `_` are displayed with hyphens `-` in the help output.
+- Sorted the output of "Available Commands" section in the `help` command so that they appear in alphabetical order.
+- When executing a group of commands, it shows the help only for the group, not the complete help.
+
+
+### Removed
+
+
 ## [0.1.6] - 2025-06-17
 
 ### Added

--- a/docs/docs/es/user-guide/output.md
+++ b/docs/docs/es/user-guide/output.md
@@ -48,10 +48,10 @@ A continuación, se describen las funciones más utilizadas:
   out.var_dump(sample_dict)
   ```
 
-- **`out.LiveText`**
-  Es una clase que permite actualizar en vivo la salida de texto en la terminal. Es útil para mostrar barras de progreso o contadores que se actualizan dinámicamente.
+- **`out.live`**
+  Metodo que permite actualizar en vivo la salida de texto en la terminal. Es útil para mostrar barras de progreso o contadores que se actualizan dinámicamente.
   ```python
-  live_text = out.LiveText("Starting...")
+  live_text = out.live("Starting...")
   live_text.info("Process running")
   live_text.warn("Retrying operation")
   live_text.success("Operation completed", end=False)
@@ -100,7 +100,7 @@ class OutCommand(command.Command):
         print('')
         print('Live text')
         print('-' * 80)
-        live_text = out.LiveText("Starting...")
+        live_text = out.live("Starting...")
         time.sleep(1)
         live_text.info("Process running")
         time.sleep(1)

--- a/fire/main.py
+++ b/fire/main.py
@@ -21,13 +21,13 @@ def install(cmd, _global: False):
         out.critical('No path for install')
     fire_path = f'{install_path}/fire'
     out.info(f'Command available at {fire_path}')
+    pyproject_path = cmd.app.path('pyproject.toml')
     with open(fire_path, 'w') as fp:
         fp.write(
             '\n'.join(
                 [
                     '#!/bin/bash',
-                    f'cd {cmd.app.path()}',
-                    'rye run fire "$@"',
+                    f'rye run --pyproject {pyproject_path} fire "$@"',
                 ]
             )
         )
@@ -65,7 +65,7 @@ def coverage(cmd):
     '''
     Launch tests with coverage
     '''
-    bash = 'poetry run coverage run -m pytest && poetry run coverage html'
+    bash = 'rye run coverage run -m pytest && rye run coverage html'
     cmd.app.shell(bash, capture_output=False)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "CliFire"
-version = "0.1.6"
+version = "0.1.7"
 description = "Minimal CLI framework to build Python commands quickly and elegantly."
 authors = [
     { name = "Roberto Lizana", email = "rober.lizana@gmail.com" }
@@ -46,6 +46,7 @@ skip-string-normalization = true
 
 [flake8]
 inline-quotes = "'"
+multiline-quotes = "'"
 docstring-quotes = "'"
 
 [project.scripts]

--- a/src/clifire/command.py
+++ b/src/clifire/command.py
@@ -117,7 +117,9 @@ class Command:
         self._options = {}
         self.app = app
         self._fields_update()
-        self.command_line = ''
+        self.command_line = command_line
+        self.extra_args = []
+        self.init()
 
     @property
     def context(self):
@@ -174,6 +176,8 @@ class Command:
             name = name.replace('-', '_')
             if name not in self._options:
                 if name not in self.app.options:
+                    out.debug2(f'Extra option "{part}"')
+                    self.extra_args.append(part)
                     continue
                 field, _value = self.app.options[name]
                 if isinstance(field, str):
@@ -197,7 +201,9 @@ class Command:
         arg_names = self._argument_names.copy()
         for index, argument in enumerate(arguments):
             if not arg_names:
-                break
+                out.debug2(f'Extra argument "{argument}"')
+                self.extra_args.append(argument)
+                continue
             name = arg_names.pop(0)
             if self._fields[name].type == list:
                 out.debug2(f'Argument "{name}" = {arguments[index:]}')
@@ -212,10 +218,9 @@ class Command:
         self._fields_check()
 
     def launch(self, command_line: str):
+        self.command_line = command_line
         out.debug(f'Launching command "{self._name}"')
         self.parse(command_line)
-        out.debug(f'Init command "{self._name}"')
-        self.init()
         out.debug(f'Running command "{self._name}"')
         return self.fire()
 

--- a/src/clifire/commands/help.py
+++ b/src/clifire/commands/help.py
@@ -56,6 +56,7 @@ class CommandHelp(command.Command):
             field = cmd._options[name]
             if isinstance(field, str):
                 field = cmd._fields[field]
+            name = name.replace('_', '-')
             name = f'-{name}' if len(name) == 1 else f'--{name}'
             options.setdefault(field, []).append(name)
         if not options:
@@ -81,6 +82,7 @@ class CommandHelp(command.Command):
             field, _value = self.app.options[name]
             if isinstance(field, str):
                 field, _value = self.app.options[field]
+            name = name.replace('_', '-')
             name = f'-{name}' if len(name) == 1 else f'--{name}'
             options.setdefault(field, []).append(name)
         if not options:
@@ -127,7 +129,7 @@ class CommandHelp(command.Command):
         for key in sorted(groups.keys()):
             if key and key != cmd._name:
                 data.append({'name': f'\n[green]{key}[/green]', 'help': ''})
-            data += groups[key]
+            data += sorted(groups[key], key=lambda item: item['name'])
         out.table(
             data,
             border=False,

--- a/src/clifire/main.py
+++ b/src/clifire/main.py
@@ -31,7 +31,7 @@ def load_file(filename):
 
 
 def main(command_line: str = None):
-    app = application.App(name='CliFire', version='0.1.6')
+    app = application.App(name='CliFire', version='0.1.7')
     current_dir = os.getcwd()
     out.debug(f'Search commands in {current_dir} folder and parents')
     loaded = False

--- a/src/clifire/out.py
+++ b/src/clifire/out.py
@@ -1,14 +1,26 @@
+import atexit
 import re
 import sys
 import threading
 import time
 from typing import Any
 
+from rich import traceback
 from rich.console import Console
 from rich.live import Live
+from rich.prompt import Prompt
 from rich.table import Table
 
+traceback.install(
+    show_locals=True,
+    theme='monokai',
+    suppress=[],
+    max_frames=2,
+)
+
 CONSOLE = Console()
+CONSOLE_WIDTH = CONSOLE.width
+
 COLOR_NORMAL = 'white'
 COLOR_DEBUG = 'grey50'
 COLOR_DEBUG2 = 'bright_black'
@@ -18,12 +30,29 @@ COLOR_WARN = 'yellow'
 COLOR_ERROR = 'red'
 
 
+def setup(ansi: bool = True):
+    if ansi:
+        CONSOLE.no_color = False
+        CONSOLE.highlight = True
+        CONSOLE.soft_wrap = True
+        CONSOLE.width = CONSOLE_WIDTH
+        debug('Console output setup with ANSI')
+    else:
+        CONSOLE.no_color = True
+        CONSOLE.highlight = False
+        CONSOLE.soft_wrap = False
+        CONSOLE.width = 10000
+        debug('Console output setup with no ANSI')
+
+
 class LiveText:
     def __init__(self, text: str = '', refresh_per_second: int = 10):
         self._live = None
         self._running = False
         self._thread = None
         self._text = ''
+        atexit.register(self.cancel)
+        self.elapsed_time = 0
         self.refresh_per_second = refresh_per_second
         self.info(text)
         self.start()
@@ -36,15 +65,15 @@ class LiveText:
         with Live(
             console=CONSOLE,
             refresh_per_second=self.refresh_per_second,
-            # transient=True
         ) as live:
             self._live = live
             self._live.update(self._text)
             start_time = time.time()
             while self._running:
-                elapsed_time = time.time() - start_time
+                self.elapsed_time = time.time() - start_time
                 display_message = (
-                    f'[grey0]({elapsed_time: .1f}s)[/grey0] {self._text}'
+                    f'[grey0]({self.elapsed_time: .1f}s)[/grey0] '
+                    f'{self._text}\n'
                 )
                 self._live.update(display_message)
                 time.sleep(1 / self.refresh_per_second)
@@ -57,14 +86,19 @@ class LiveText:
         self._thread = threading.Thread(target=self._start, daemon=True)
         self._thread.start()
 
+    def cancel(self):
+        self._text = ''
+        self.stop()
+
     def stop(self):
         self._running = False
-        if self._thread:
-            self._thread.join()
-
-    def cancel(self):
-        self._live.transient = True
-        self.stop()
+        if self._text != '':
+            CONSOLE.print(self._text)
+        if self._thread and self._thread.is_alive():
+            self._live.transient = True
+            self._text = text_color('')
+            self._thread.join(timeout=1.0)
+            self._live.update(self._text)
 
     def info(self, text: str, end=False):
         self._text = text_color(text, color=COLOR_INFO)
@@ -87,6 +121,17 @@ class LiveText:
             self.stop()
 
 
+_current_live = None
+
+
+def live(text: str = '', refresh_per_second: int = 10):
+    global _current_live
+    if _current_live:
+        return _current_live
+    _current_live = LiveText(text, refresh_per_second=refresh_per_second)
+    return _current_live
+
+
 def table(
     data: list[dict[str, Any]],
     title: str = '',
@@ -94,11 +139,12 @@ def table(
     show_header: bool = True,
     style_cols: dict[str, str] = None,
     padding: tuple = None,
+    style: str = None,
 ):
     if not data:
         return
     keys = list(data[0].keys())
-    tbl = Table(title=title, show_header=show_header)
+    tbl = Table(title=title, show_header=show_header, style=style)
     if not border:
         tbl.box = None
         tbl.padding = (0, 2)
@@ -106,10 +152,15 @@ def table(
         tbl.padding = padding
     for key in keys:
         justify = 'right' if isinstance(data[0][key], (int, float)) else 'left'
+        _style_col = None
+        if isinstance(style_cols, dict):
+            _style_col = style_cols.get(key, None)
+        elif isinstance(style_cols, str):
+            _style_col = style_cols
         tbl.add_column(
             key.replace('_', ' ').capitalize(),
             justify=justify,
-            style=style_cols.get(key, '') if style_cols else None,
+            style=_style_col,
         )
     for row in data:
         tbl.add_row(*(str(row.get(key, '')) for key in keys))
@@ -167,3 +218,9 @@ def debug2(text: str) -> None:
 
 def var_dump(var) -> None:
     CONSOLE.print(var, highlight=True)
+
+
+def ask(text: str, choices: list[str] = ['y', 'n']):  # noqa: B006
+    return Prompt.ask(
+        text, choices=choices, default=choices[0] if choices else None
+    )

--- a/src/clifire/template.py
+++ b/src/clifire/template.py
@@ -2,13 +2,18 @@ import os
 import re
 
 import jinja2
+from clifire import application
 
 
 class Template:
     def __init__(self, template_folder: str):
+        self.template_folder = template_folder
         self.jinja2 = jinja2.Environment(
             loader=jinja2.FileSystemLoader(template_folder)
         )
+
+    def path(self, *args: list[str]) -> str:
+        return application.App.current_app.path(self.template_folder, *args)
 
     def render(self, template, **args):
         args['os'] = os

--- a/tests/sample/out.py
+++ b/tests/sample/out.py
@@ -38,7 +38,11 @@ class CommandInfoAsk(command.Command):
 
     _name = 'info.ask'
 
-    text = command.Field(pos=1, help='Message text to show in the console')
+    text = command.Field(
+        pos=1,
+        force_type=str,
+        help='Message text to show in the console',
+    )
     type = command.Field(
         help='Color can be: info, warn or error',
         default='info',

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -182,8 +182,6 @@ def test_command_options():
     cmd.parse('contact NAME --option')
     assert hasattr(cmd, 'option')
     assert cmd.option is True
-    assert not hasattr(cmd, 'option_init')
-    cmd.init()
     assert hasattr(cmd, 'option_init')
 
     cmd = app.get_command('contact')

--- a/tests/test_command_help.py
+++ b/tests/test_command_help.py
@@ -44,16 +44,32 @@ def test_command_help_without_arguments(capsys):
 
 
 def test_command_help_without_global_options(capsys):
+    app = application.App(name='sample', version='1.0.99')
+    app.fire('help')
+    printed = output(capsys)
+    assert '--no-ansi' in printed
+    assert '--verbose' in printed
+
     app = application.App(
-        name='sample', version='1.0.99', option_verbose=False
+        name='sample',
+        version='1.0.99',
+        option_verbose=False,
+        option_ansi=False,
     )
     app.fire('help')
     printed = output(capsys)
     assert 'Description' in printed
-    assert 'Global options:' not in printed
+    assert 'Global options:' in printed
+    assert '--no-ansi' not in printed
+    assert '--verbose' not in printed
     assert 'Arguments' in printed
     assert 'version' in printed
     assert 'help' in printed
+
+    app.options = {}
+    app.fire('help')
+    printed = output(capsys)
+    assert 'Global options:' not in printed
 
 
 def test_command_help_with_groups(capsys):
@@ -70,19 +86,21 @@ def test_command_help_with_groups(capsys):
         _help = 'Set config value'
 
     app = application.App(name='sample', version='1.0.99')
-    app.add_command(CommandDbCreate)
-    app.add_command(CommandDbDrop)
-    app.add_command(CommandConfigSet)
+    app.add_commands(
+        [
+            CommandDbCreate,
+            CommandDbDrop,
+            CommandConfigSet,
+        ]
+    )
 
     app.fire('help')
     printed = output(capsys)
     assert 'db' in printed
     assert 'config' in printed
-
     assert 'create' in printed
     assert 'drop' in printed
     assert 'set' in printed
-
     assert 'Create database' in printed
     assert 'Drop database' in printed
     assert 'Set config value' in printed
@@ -90,3 +108,11 @@ def test_command_help_with_groups(capsys):
     db_pos = printed.find('db')
     config_pos = printed.find('config')
     assert config_pos < db_pos
+
+    app.fire('db create --help')
+    printed = output(capsys)
+    assert 'Create database' in printed
+
+    app.fire('db create -h')
+    printed = output(capsys)
+    assert 'Create database' in printed

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,3 +56,30 @@ def test_config(temp_dir):
     assert conf.get('non_existent', 'default') == 'default'
     assert str(conf) == repr(conf)
     assert isinstance(str(conf), str)
+
+    assert 'new_key' not in conf
+    conf['new_key'] = 'new_value'
+    assert conf['new_key'] == 'new_value'
+
+
+def test_config_query(temp_dir):
+    config_file = os.path.join(temp_dir, 'config.yaml')
+    test_data = {
+        'parent': {
+            'child_1': {
+                'name': 'Rob',
+            },
+            'name': 'Parent',
+        }
+    }
+    conf = config.Config(config_file=config_file, create=False, **test_data)
+    assert conf.query_get('parent.child_1.name') == 'Rob'
+    assert conf.query_get('parent.child_2.name', 'Not Exist') == 'Not Exist'
+    conf.query_set('parent.child_1.name', 'Changed')
+    assert conf.query_get('parent.child_1.name') == 'Changed'
+    with pytest.raises(KeyError):
+        conf.query_set('parent.child_2.name', 'Changed')
+    conf.query_del('parent.child_1.name')
+    assert conf.query_get('parent.child_1.name', 'Deleted') == 'Deleted'
+    with pytest.raises(KeyError):
+        conf.query_del('parent.child_2.name')

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -14,6 +14,7 @@ def temp_dir():
 def test_app_template(temp_dir):
     folder = os.path.join(os.path.dirname(__file__), 'sample', 'template')
     app = application.App(template_folder=folder)
+    assert folder == app.template.path()
     kwargs = {
         'title': 'sample',
         'user': 'root',


### PR DESCRIPTION
## [0.1.7] - 2025-07-06

### Added
- Add `get`, `set`, and `contains` methods to the `Config` class so that it works like a dictionary.
- Global options `--help` and `-h` to display command help
- Add `extra_args` to `Commands` with the extra arguments that are passed
- Add `query_get`, `query_set`, and `query_del` methods to the `Config` class to allow get, set, and delete operations on the configuration using `.` to navigate through configuration attributes.
- Added the `ask` method to `out` for interactive user prompts.
- Added the `path` method to `template` to obtain the absolute path of a template file.
- New global option `--no-ansi` to disable ANSI color codes in the output.
- Improved exception output to display the full traceback.
- Crear metodo `live`en `out` para gestionar que solo exista una instancia de `LiveText`.
- Add new `add_commands` method to the `Application` class to add multiple commands.
- When use `shell` method of the `Application` class, if set a path register it is logged in the debug.

### Changed
- Improved the `LiveText` class from `out` to ensure that all created `LiveText` instances are canceled at program exit using the `atexit` library.
- Improved the `LiveText` class from `out` to expose the elapsed time since the object was created in an `elapsed_time` variable.
- Modified the `init` command so that it is executed immediately after its constructor, as it did not make sense to call it before the execution of the `fire` method since there was no code in between.
- Modified the `table` method of the `out` class to accept an optional `style` argument that allows defining the table style. If not specified, the default style is used.

### Fixed
- When using the `shell` method of the `Application` class with a specific path, after execution it ensures to return to the previous path.
- The installation of the global bash script command `fire` previously required running `cd` to launch it. Now, it no longer performs `cd`, so when the `fire` command is executed, it reads the user's current directory. The command is installed with `fire install`.
- Fixed the `help` command so that options with underscores `_` are displayed with hyphens `-` in the help output.
- Sorted the output of "Available Commands" section in the `help` command so that they appear in alphabetical order.
- When executing a group of commands, it shows the help only for the group, not the complete help.
- In the global options, the underscore `_` is not replaced by a hyphen `-` in the help output.
- Clean the command line before processing it to obtain the global options.
