### PR TITLE
[IMP] version 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2025-07-15
+
+### Added
+
+### Changed
+
+### Fixed
+- Version 0.1.8 cannot be used on pypi.org, it was accidentally removed and is missing, the version is being changed so it can be published.
+
 ## [0.1.8] - 2025-07-07
 
 ### Added

--- a/fire/main.py
+++ b/fire/main.py
@@ -65,13 +65,11 @@ def publish(cmd):
     '''
     Publish then package
     '''
-    live = out.LiveText('Puiblising ...')
     res = cmd.app.shell('rye publish -y', capture_output=False)
     if res:
-        live.success('Published')
+        out.success('Published')
     else:
-        live.error('Error on publish package')
-        return 1
+        out.critical('Error on publish package')
 
 
 @command.fire

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "CliFire"
-version = "0.1.8"
+version = "0.1.9"
 description = "Minimal CLI framework to build Python commands quickly and elegantly."
 authors = [
     { name = "Roberto Lizana", email = "rober.lizana@gmail.com" }
@@ -41,7 +41,7 @@ fire = 'python -m src.clifire.main'
 
 [tool.black]
 line-length = 79
-target-version = ["py310"]
+target-version = ["py38"]
 skip-string-normalization = true
 
 [flake8]

--- a/src/clifire/main.py
+++ b/src/clifire/main.py
@@ -31,7 +31,7 @@ def load_file(filename):
 
 
 def main(command_line: str = None):
-    app = application.App(name='CliFire', version='0.1.8')
+    app = application.App(name='CliFire', version='0.1.9')
     current_dir = os.getcwd()
     out.debug(f'Search commands in {current_dir} folder and parents')
     loaded = False


### PR DESCRIPTION
## [0.1.9] - 2025-07-15

### Added

### Changed

### Fixed
- Version 0.1.8 cannot be used on pypi.org, it was accidentally removed and is missing, the version is being changed so it can be published.